### PR TITLE
Add support for performance profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This list includes devices that were successfully tested with tuxedo-rs.
 Since I have limited access to hardware, please consider adding your device(s) to the list.
 
 + TUXEDO Aura 15 Gen1
++ TUXEDO Pulse 15 Gen1
 
 ## Installation
 
@@ -119,7 +120,7 @@ ninja -C _build install
 
 - [x] Ioctl abstraction for tuxedo_io
 - [x] Sysfs abstraction for tuxedo_keyboard
-- [ ] Support for hardware based on uniwill
+- [x] Support for hardware based on uniwill
 - [x] Daemon with DBus interface for user space application
 - [x] Client library for interacting with the daemon
 - [ ] CLI that interacts with the daemon

--- a/tailor_api/src/lib.rs
+++ b/tailor_api/src/lib.rs
@@ -1,9 +1,9 @@
 mod color;
 mod fan;
-mod profile;
 mod led;
+mod profile;
 
 pub use color::{Color, ColorPoint, ColorProfile, ColorTransition};
 pub use fan::FanProfilePoint;
-pub use profile::{LedProfile, ProfileInfo};
 pub use led::LedDeviceInfo;
+pub use profile::{LedProfile, ProfileInfo};

--- a/tailor_api/src/profile.rs
+++ b/tailor_api/src/profile.rs
@@ -2,6 +2,7 @@
 pub struct ProfileInfo {
     pub fans: Vec<String>,
     pub leds: Vec<LedProfile>,
+    pub performance_profile: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]

--- a/tailor_client/src/dbus/mod.rs
+++ b/tailor_client/src/dbus/mod.rs
@@ -1,7 +1,9 @@
 mod fan;
 mod led;
 mod profiles;
+mod performance;
 
 pub(crate) use fan::FanProxy;
 pub(crate) use led::LedProxy;
 pub(crate) use profiles::ProfilesProxy;
+pub(crate) use performance::PerformanceProxy;

--- a/tailor_client/src/dbus/mod.rs
+++ b/tailor_client/src/dbus/mod.rs
@@ -1,9 +1,9 @@
 mod fan;
 mod led;
-mod profiles;
 mod performance;
+mod profiles;
 
 pub(crate) use fan::FanProxy;
 pub(crate) use led::LedProxy;
-pub(crate) use profiles::ProfilesProxy;
 pub(crate) use performance::PerformanceProxy;
+pub(crate) use profiles::ProfilesProxy;

--- a/tailor_client/src/dbus/performance.rs
+++ b/tailor_client/src/dbus/performance.rs
@@ -8,11 +8,11 @@ use zbus::{dbus_proxy, fdo};
 trait Performance {
     /// Temporarily override the performance profile. Please note that this will not survive a
     /// restart as the performance profile is handled by the overall profile configuration.
-    async fn set_performance_profile(&self, name: &str, value: &str) -> fdo::Result<()>;
+    async fn set_profile(&self, name: &str, value: &str) -> fdo::Result<()>;
 
     /// Read the current performance profile.
-    async fn get_performance_profile(&self, name: &str) -> fdo::Result<String>;
+    async fn get_profile(&self, name: &str) -> fdo::Result<String>;
 
     /// Read the list of supported performance profiles.
-    async fn list_performance_profiles(&self) -> fdo::Result<Vec<String>>;
+    async fn list_profiles(&self) -> fdo::Result<Vec<String>>;
 }

--- a/tailor_client/src/dbus/performance.rs
+++ b/tailor_client/src/dbus/performance.rs
@@ -1,0 +1,14 @@
+use zbus::{dbus_proxy, fdo};
+
+#[dbus_proxy(
+    interface = "com.tux.Tailor.Performance",
+    default_service = "com.tux.Tailor",
+    default_path = "/com/tux/Tailor"
+)]
+trait Performance {
+    async fn set_performance_profile(&self, name: &str, value: &str) -> fdo::Result<()>;
+
+    async fn get_performance_profile(&self, name: &str) -> fdo::Result<String>;
+
+    async fn list_performance_profiles(&self) -> fdo::Result<Vec<String>>;
+}

--- a/tailor_client/src/dbus/performance.rs
+++ b/tailor_client/src/dbus/performance.rs
@@ -8,11 +8,11 @@ use zbus::{dbus_proxy, fdo};
 trait Performance {
     /// Temporarily override the performance profile. Please note that this will not survive a
     /// restart as the performance profile is handled by the overall profile configuration.
-    async fn set_profile(&self, name: &str, value: &str) -> fdo::Result<()>;
+    async fn set_performance_profile(&self, name: &str, value: &str) -> fdo::Result<()>;
 
     /// Read the current performance profile.
-    async fn get_profile(&self, name: &str) -> fdo::Result<String>;
+    async fn get_performance_profile(&self, name: &str) -> fdo::Result<String>;
 
     /// Read the list of supported performance profiles.
-    async fn list_profiles(&self) -> fdo::Result<Vec<String>>;
+    async fn list_performance_profiles(&self) -> fdo::Result<Vec<String>>;
 }

--- a/tailor_client/src/dbus/performance.rs
+++ b/tailor_client/src/dbus/performance.rs
@@ -6,9 +6,13 @@ use zbus::{dbus_proxy, fdo};
     default_path = "/com/tux/Tailor"
 )]
 trait Performance {
-    async fn set_performance_profile(&self, name: &str, value: &str) -> fdo::Result<()>;
+    /// Temporarily override the performance profile. Please note that this will not survive a
+    /// restart as the performance profile is handled by the overall profile configuration.
+    async fn set_profile(&self, name: &str, value: &str) -> fdo::Result<()>;
 
-    async fn get_performance_profile(&self, name: &str) -> fdo::Result<String>;
+    /// Read the current performance profile.
+    async fn get_profile(&self, name: &str) -> fdo::Result<String>;
 
-    async fn list_performance_profiles(&self) -> fdo::Result<Vec<String>>;
+    /// Read the list of supported performance profiles.
+    async fn list_profiles(&self) -> fdo::Result<Vec<String>>;
 }

--- a/tailor_client/src/dbus/profiles.rs
+++ b/tailor_client/src/dbus/profiles.rs
@@ -22,6 +22,8 @@ trait Profiles {
 
     async fn get_active_performance_profile_name(&self) -> fdo::Result<String>;
 
+    async fn set_active_performance_profile_name(&self, name: &str) -> fdo::Result<()>;
+
     async fn get_available_performance_profile_names(&self) -> fdo::Result<Vec<String>>;
 
     async fn get_number_of_fans(&self) -> fdo::Result<u8>;

--- a/tailor_client/src/dbus/profiles.rs
+++ b/tailor_client/src/dbus/profiles.rs
@@ -20,10 +20,6 @@ trait Profiles {
 
     async fn get_active_profile_name(&self) -> fdo::Result<String>;
 
-    async fn get_active_performance_profile_name(&self) -> fdo::Result<String>;
-
-    async fn set_active_performance_profile_name(&self, name: &str) -> fdo::Result<()>;
-
     async fn get_available_performance_profile_names(&self) -> fdo::Result<Vec<String>>;
 
     async fn get_number_of_fans(&self) -> fdo::Result<u8>;

--- a/tailor_client/src/dbus/profiles.rs
+++ b/tailor_client/src/dbus/profiles.rs
@@ -20,8 +20,6 @@ trait Profiles {
 
     async fn get_active_profile_name(&self) -> fdo::Result<String>;
 
-    async fn get_available_performance_profile_names(&self) -> fdo::Result<Vec<String>>;
-
     async fn get_number_of_fans(&self) -> fdo::Result<u8>;
 
     async fn get_led_devices(&self) -> fdo::Result<String>;

--- a/tailor_client/src/dbus/profiles.rs
+++ b/tailor_client/src/dbus/profiles.rs
@@ -20,6 +20,10 @@ trait Profiles {
 
     async fn get_active_profile_name(&self) -> fdo::Result<String>;
 
+    async fn get_active_performance_profile_name(&self) -> fdo::Result<String>;
+
+    async fn get_available_performance_profile_names(&self) -> fdo::Result<Vec<String>>;
+
     async fn get_number_of_fans(&self) -> fdo::Result<u8>;
 
     async fn get_led_devices(&self) -> fdo::Result<String>;

--- a/tailor_client/src/lib.rs
+++ b/tailor_client/src/lib.rs
@@ -139,6 +139,13 @@ impl<'a> TailorConnection<'a> {
         Ok(self.profiles.get_active_performance_profile_name().await?)
     }
 
+    pub async fn set_active_performance_profile_name(&self, name: &str) -> ClientResult<()> {
+        Ok(self
+            .profiles
+            .set_active_performance_profile_name(name)
+            .await?)
+    }
+
     pub async fn get_available_performance_profile_names(&self) -> ClientResult<Vec<String>> {
         Ok(self
             .profiles

--- a/tailor_client/src/lib.rs
+++ b/tailor_client/src/lib.rs
@@ -164,18 +164,19 @@ impl<'a> TailorConnection<'a> {
 }
 
 impl<'a> TailorConnection<'a> {
-    pub async fn set_performance_profile(&self, name: &str, value: &str) -> ClientResult<()> {
-        Ok(self
-            .performance
-            .set_performance_profile(name, value)
-            .await?)
+    /// Temporarily override the performance profile. Please note that this will not survive a
+    /// restart as the performance profile is handled by the overall profile configuration.
+    pub async fn set_profile(&self, name: &str, value: &str) -> ClientResult<()> {
+        Ok(self.performance.set_profile(name, value).await?)
     }
 
-    pub async fn get_performance_profile(&self, name: &str) -> ClientResult<String> {
-        Ok(self.performance.get_performance_profile(name).await?)
+    /// Read the current performance profile.
+    pub async fn get_profile(&self, name: &str) -> ClientResult<String> {
+        Ok(self.performance.get_profile(name).await?)
     }
 
-    pub async fn list_performance_profiles(&self) -> ClientResult<Vec<String>> {
-        Ok(self.performance.list_performance_profiles().await?)
+    /// Read the list of supported performance profiles.
+    pub async fn list_profiles(&self) -> ClientResult<Vec<String>> {
+        Ok(self.performance.list_profiles().await?)
     }
 }

--- a/tailor_client/src/lib.rs
+++ b/tailor_client/src/lib.rs
@@ -14,6 +14,7 @@ pub struct TailorConnection<'a> {
     profiles: dbus::ProfilesProxy<'a>,
     led: dbus::LedProxy<'a>,
     fan: dbus::FanProxy<'a>,
+    performance: dbus::PerformanceProxy<'a>,
 }
 
 impl<'a> TailorConnection<'a> {
@@ -23,11 +24,13 @@ impl<'a> TailorConnection<'a> {
         let profiles = dbus::ProfilesProxy::new(&connection).await?;
         let keyboard = dbus::LedProxy::new(&connection).await?;
         let fan = dbus::FanProxy::new(&connection).await?;
+        let performance = dbus::PerformanceProxy::new(&connection).await?;
 
         Ok(Self {
             profiles,
             led: keyboard,
             fan,
+            performance,
         })
     }
 }
@@ -135,17 +138,6 @@ impl<'a> TailorConnection<'a> {
         Ok(self.profiles.get_active_profile_name().await?)
     }
 
-    pub async fn get_active_performance_profile_name(&self) -> ClientResult<String> {
-        Ok(self.profiles.get_active_performance_profile_name().await?)
-    }
-
-    pub async fn set_active_performance_profile_name(&self, name: &str) -> ClientResult<()> {
-        Ok(self
-            .profiles
-            .set_active_performance_profile_name(name)
-            .await?)
-    }
-
     pub async fn get_available_performance_profile_names(&self) -> ClientResult<Vec<String>> {
         Ok(self
             .profiles
@@ -168,5 +160,22 @@ impl<'a> TailorConnection<'a> {
 
     pub async fn reload(&self) -> ClientResult<()> {
         Ok(self.profiles.reload().await?)
+    }
+}
+
+impl<'a> TailorConnection<'a> {
+    pub async fn set_performance_profile(&self, name: &str, value: &str) -> ClientResult<()> {
+        Ok(self
+            .performance
+            .set_performance_profile(name, value)
+            .await?)
+    }
+
+    pub async fn get_performance_profile(&self, name: &str) -> ClientResult<String> {
+        Ok(self.performance.get_performance_profile(name).await?)
+    }
+
+    pub async fn list_performance_profiles(&self) -> ClientResult<Vec<String>> {
+        Ok(self.performance.list_performance_profiles().await?)
     }
 }

--- a/tailor_client/src/lib.rs
+++ b/tailor_client/src/lib.rs
@@ -138,13 +138,6 @@ impl<'a> TailorConnection<'a> {
         Ok(self.profiles.get_active_profile_name().await?)
     }
 
-    pub async fn get_available_performance_profile_names(&self) -> ClientResult<Vec<String>> {
-        Ok(self
-            .profiles
-            .get_available_performance_profile_names()
-            .await?)
-    }
-
     pub async fn set_active_global_profile_name(&self, name: &str) -> ClientResult<()> {
         Ok(self.profiles.set_active_profile_name(name).await?)
     }

--- a/tailor_client/src/lib.rs
+++ b/tailor_client/src/lib.rs
@@ -160,16 +160,16 @@ impl<'a> TailorConnection<'a> {
     /// Temporarily override the performance profile. Please note that this will not survive a
     /// restart as the performance profile is handled by the overall profile configuration.
     pub async fn set_performance_profile(&self, name: &str, value: &str) -> ClientResult<()> {
-        Ok(self.performance.set_performance_profile(name, value).await?)
+        Ok(self.performance.set_profile(name, value).await?)
     }
 
     /// Read the current performance profile.
     pub async fn get_performance_profile(&self, name: &str) -> ClientResult<String> {
-        Ok(self.performance.get_performance_profile(name).await?)
+        Ok(self.performance.get_profile(name).await?)
     }
 
     /// Read the list of supported performance profiles.
     pub async fn list_performance_profiles(&self) -> ClientResult<Vec<String>> {
-        Ok(self.performance.list_performance_profiles().await?)
+        Ok(self.performance.list_profiles().await?)
     }
 }

--- a/tailor_client/src/lib.rs
+++ b/tailor_client/src/lib.rs
@@ -159,17 +159,17 @@ impl<'a> TailorConnection<'a> {
 impl<'a> TailorConnection<'a> {
     /// Temporarily override the performance profile. Please note that this will not survive a
     /// restart as the performance profile is handled by the overall profile configuration.
-    pub async fn set_profile(&self, name: &str, value: &str) -> ClientResult<()> {
-        Ok(self.performance.set_profile(name, value).await?)
+    pub async fn set_performance_profile(&self, name: &str, value: &str) -> ClientResult<()> {
+        Ok(self.performance.set_performance_profile(name, value).await?)
     }
 
     /// Read the current performance profile.
-    pub async fn get_profile(&self, name: &str) -> ClientResult<String> {
-        Ok(self.performance.get_profile(name).await?)
+    pub async fn get_performance_profile(&self, name: &str) -> ClientResult<String> {
+        Ok(self.performance.get_performance_profile(name).await?)
     }
 
     /// Read the list of supported performance profiles.
-    pub async fn list_profiles(&self) -> ClientResult<Vec<String>> {
-        Ok(self.performance.list_profiles().await?)
+    pub async fn list_performance_profiles(&self) -> ClientResult<Vec<String>> {
+        Ok(self.performance.list_performance_profiles().await?)
     }
 }

--- a/tailor_client/src/lib.rs
+++ b/tailor_client/src/lib.rs
@@ -4,7 +4,7 @@ mod dbus;
 mod error;
 
 pub use error::ClientError;
-use tailor_api::{Color, ColorProfile, FanProfilePoint, ProfileInfo, LedDeviceInfo};
+use tailor_api::{Color, ColorProfile, FanProfilePoint, LedDeviceInfo, ProfileInfo};
 use zbus::Connection;
 
 pub type ClientResult<T> = Result<T, ClientError>;
@@ -33,11 +33,7 @@ impl<'a> TailorConnection<'a> {
 }
 
 impl<'a> TailorConnection<'a> {
-    pub async fn add_led_profile(
-        &self,
-        name: &str,
-        profile: &ColorProfile,
-    ) -> ClientResult<()> {
+    pub async fn add_led_profile(&self, name: &str, profile: &ColorProfile) -> ClientResult<()> {
         let value = serde_json::to_string(profile)?;
         Ok(self.led.add_profile(name, &value).await?)
     }
@@ -137,6 +133,17 @@ impl<'a> TailorConnection<'a> {
 
     pub async fn get_active_global_profile_name(&self) -> ClientResult<String> {
         Ok(self.profiles.get_active_profile_name().await?)
+    }
+
+    pub async fn get_active_performance_profile_name(&self) -> ClientResult<String> {
+        Ok(self.profiles.get_active_performance_profile_name().await?)
+    }
+
+    pub async fn get_available_performance_profile_names(&self) -> ClientResult<Vec<String>> {
+        Ok(self
+            .profiles
+            .get_available_performance_profile_names()
+            .await?)
     }
 
     pub async fn set_active_global_profile_name(&self, name: &str) -> ClientResult<()> {

--- a/tailor_client/tests/tests.rs
+++ b/tailor_client/tests/tests.rs
@@ -201,20 +201,11 @@ async fn test_keyboard() {
     ]);
 
     // Add profile
-    connection
-        .add_led_profile(name, &profile)
-        .await
-        .unwrap();
+    connection.add_led_profile(name, &profile).await.unwrap();
     // Overwrite profile
-    connection
-        .add_led_profile(name, &profile)
-        .await
-        .unwrap();
+    connection.add_led_profile(name, &profile).await.unwrap();
     // Get profile
-    assert_eq!(
-        connection.get_led_profile(name).await.unwrap(),
-        profile
-    );
+    assert_eq!(connection.get_led_profile(name).await.unwrap(), profile);
     // List should contain name
     assert!(connection
         .list_led_profiles()
@@ -256,10 +247,7 @@ async fn test_keyboard() {
     connection.remove_led_profile(name).await.unwrap();
 
     // Remove profile
-    connection
-        .remove_led_profile(second_name)
-        .await
-        .unwrap();
+    connection.remove_led_profile(second_name).await.unwrap();
     // Remove profile again (should fail)
     connection
         .remove_led_profile(second_name)

--- a/tailord/src/dbus/fan.rs
+++ b/tailord/src/dbus/fan.rs
@@ -55,11 +55,12 @@ impl FanInterface {
             let profiles = util::get_profiles(PROFILE_DIR).await?;
 
             for profile in profiles {
-                let mut data = if let Ok(data) = util::read_json::<ProfileInfo>(PROFILE_DIR, &profile).await {
-                    data
-                } else {
-                    continue;
-                };
+                let mut data =
+                    if let Ok(data) = util::read_json::<ProfileInfo>(PROFILE_DIR, &profile).await {
+                        data
+                    } else {
+                        continue;
+                    };
                 let mut changed = false;
 
                 for fan in &mut data.fans {

--- a/tailord/src/dbus/led.rs
+++ b/tailord/src/dbus/led.rs
@@ -62,11 +62,12 @@ impl LedInterface {
             let profiles = util::get_profiles(PROFILE_DIR).await?;
 
             for profile in profiles {
-                let mut data = if let Ok(data) = util::read_json::<ProfileInfo>(PROFILE_DIR, &profile).await {
-                    data
-                } else {
-                    continue;
-                };
+                let mut data =
+                    if let Ok(data) = util::read_json::<ProfileInfo>(PROFILE_DIR, &profile).await {
+                        data
+                    } else {
+                        continue;
+                    };
                 let mut changed = false;
 
                 for led in &mut data.leds {

--- a/tailord/src/dbus/mod.rs
+++ b/tailord/src/dbus/mod.rs
@@ -1,9 +1,9 @@
 mod fan;
 mod led;
-mod profiles;
 mod performance;
+mod profiles;
 
 pub use fan::FanInterface;
 pub use led::LedInterface;
-pub use profiles::ProfileInterface;
 pub use performance::PerformanceInterface;
+pub use profiles::ProfileInterface;

--- a/tailord/src/dbus/mod.rs
+++ b/tailord/src/dbus/mod.rs
@@ -1,7 +1,9 @@
 mod fan;
 mod led;
 mod profiles;
+mod performance;
 
 pub use fan::FanInterface;
 pub use led::LedInterface;
 pub use profiles::ProfileInterface;
+pub use performance::PerformanceInterface;

--- a/tailord/src/dbus/performance.rs
+++ b/tailord/src/dbus/performance.rs
@@ -24,7 +24,7 @@ impl PerformanceInterface {
 impl PerformanceInterface {
     /// Temporarily override the performance profile. Please note that this will not survive a
     /// restart as the performance profile is handled by the overall profile configuration.
-    async fn set_profile(&mut self, name: &str) -> fdo::Result<()> {
+    async fn set_performance_profile(&mut self, name: &str) -> fdo::Result<()> {
         self.handler()?
             .profile_sender
             .send(name.to_string())
@@ -37,12 +37,12 @@ impl PerformanceInterface {
     }
 
     /// Read the current performance profile.
-    async fn get_profile(&self) -> fdo::Result<String> {
+    async fn get_performance_profile(&self) -> fdo::Result<String> {
         Ok(self.handler()?.get_active_performance_profile().to_string())
     }
 
     /// Read the list of supported performance profiles.
-    async fn list_profiles(&self) -> fdo::Result<Vec<String>> {
+    async fn list_performance_profiles(&self) -> fdo::Result<Vec<String>> {
         Ok(self
             .handler()?
             .get_availables_performance_profiles()

--- a/tailord/src/dbus/performance.rs
+++ b/tailord/src/dbus/performance.rs
@@ -1,0 +1,51 @@
+use zbus::{dbus_interface, fdo};
+
+use crate::performance::PerformanceProfileRuntimeHandle;
+
+pub struct PerformanceInterface {
+    pub handler: Option<PerformanceProfileRuntimeHandle>,
+}
+
+impl PerformanceInterface {
+    fn handler(&self) -> fdo::Result<&PerformanceProfileRuntimeHandle> {
+        self.handler.as_ref().ok_or(fdo::Error::Failed(
+            "No performance profile handler available".to_string(),
+        ))
+    }
+
+    fn handler_mut(&mut self) -> fdo::Result<&mut PerformanceProfileRuntimeHandle> {
+        self.handler.as_mut().ok_or(fdo::Error::Failed(
+            "No performance profile handler available".to_string(),
+        ))
+    }
+}
+
+#[dbus_interface(name = "com.tux.Tailor.Performance")]
+impl PerformanceInterface {
+    async fn set_profile(&mut self, name: &str) -> fdo::Result<()> {
+        self.handler()?
+            .profile_sender
+            .send(name.to_string())
+            .await
+            .map_err(|err| {
+                fdo::Error::IOError(format!("unable to set performance profile {name}: {err}"))
+            })?;
+        self.handler_mut()?.set_active_performance_profile(name);
+        Ok(())
+    }
+
+    async fn get_profile(&self) -> fdo::Result<String> {
+        Ok(self.handler()?.get_active_performance_profile().to_string())
+    }
+
+    async fn list_profiles(&self) -> fdo::Result<Vec<String>> {
+        Ok(self
+            .handler()?
+            .get_availables_performance_profiles()
+            .map_err(|err| {
+                fdo::Error::IOError(format!(
+                    "unable to list available performance profiles: {err}"
+                ))
+            })?)
+    }
+}

--- a/tailord/src/dbus/performance.rs
+++ b/tailord/src/dbus/performance.rs
@@ -22,6 +22,8 @@ impl PerformanceInterface {
 
 #[dbus_interface(name = "com.tux.Tailor.Performance")]
 impl PerformanceInterface {
+    /// Temporarily override the performance profile. Please note that this will not survive a
+    /// restart as the performance profile is handled by the overall profile configuration.
     async fn set_profile(&mut self, name: &str) -> fdo::Result<()> {
         self.handler()?
             .profile_sender
@@ -34,10 +36,12 @@ impl PerformanceInterface {
         Ok(())
     }
 
+    /// Read the current performance profile.
     async fn get_profile(&self) -> fdo::Result<String> {
         Ok(self.handler()?.get_active_performance_profile().to_string())
     }
 
+    /// Read the list of supported performance profiles.
     async fn list_profiles(&self) -> fdo::Result<Vec<String>> {
         Ok(self
             .handler()?

--- a/tailord/src/dbus/profiles.rs
+++ b/tailord/src/dbus/profiles.rs
@@ -62,6 +62,17 @@ impl ProfileInterface {
         Profile::get_active_profile_name().await
     }
 
+    async fn get_active_performance_profile_name(&self) -> fdo::Result<String> {
+        Ok(self
+            .performance_profile_handle
+            .as_ref()
+            .ok_or(fdo::Error::Failed(
+                "No performance profile handler available".to_string(),
+            ))?
+            .performance_profile
+            .to_string())
+    }
+
     async fn get_number_of_fans(&self) -> fdo::Result<u8> {
         Ok(self.fan_handles.len() as u8)
     }

--- a/tailord/src/dbus/profiles.rs
+++ b/tailord/src/dbus/profiles.rs
@@ -15,26 +15,6 @@ pub struct ProfileInterface {
     pub performance_profile_handle: Option<PerformanceProfileRuntimeHandle>,
 }
 
-impl ProfileInterface {
-    fn performance_profile_handle(&self) -> fdo::Result<&PerformanceProfileRuntimeHandle> {
-        self.performance_profile_handle
-            .as_ref()
-            .ok_or(fdo::Error::Failed(
-                "No performance profile handler available".to_string(),
-            ))
-    }
-
-    fn performance_profile_handle_mut(
-        &mut self,
-    ) -> fdo::Result<&mut PerformanceProfileRuntimeHandle> {
-        self.performance_profile_handle
-            .as_mut()
-            .ok_or(fdo::Error::Failed(
-                "No performance profile handler available".to_string(),
-            ))
-    }
-}
-
 #[dbus_interface(name = "com.tux.Tailor.Profiles")]
 impl ProfileInterface {
     async fn add_profile(&self, name: &str, value: &str) -> fdo::Result<()> {
@@ -82,30 +62,6 @@ impl ProfileInterface {
         Profile::get_active_profile_name().await
     }
 
-    async fn set_active_performance_profile_name(&mut self, name: &str) -> fdo::Result<()> {
-        self.performance_profile_handle()?
-            .profile_sender
-            .send(name.to_string())
-            .await
-            .map_err(|err| fdo::Error::Failed(err.to_string()))?;
-        Ok(self
-            .performance_profile_handle_mut()?
-            .set_active_performance_profile(name))
-    }
-
-    async fn get_active_performance_profile_name(&self) -> fdo::Result<String> {
-        Ok(self
-            .performance_profile_handle()?
-            .get_active_performance_profile()
-            .to_string())
-    }
-
-    async fn get_available_performance_profile_names(&self) -> fdo::Result<Vec<String>> {
-        self.performance_profile_handle()?
-            .get_availables_performance_profiles()
-            .map_err(|err| fdo::Error::Failed(err.to_string()))
-    }
-
     async fn get_number_of_fans(&self) -> fdo::Result<u8> {
         Ok(self.fan_handles.len() as u8)
     }
@@ -144,13 +100,14 @@ impl ProfileInterface {
                 .map_err(|err| fdo::Error::Failed(err.to_string()))?;
         }
 
-        if let Some(perf_handle) = &self.performance_profile_handle {
+        if let Some(perf_handle) = self.performance_profile_handle.as_mut() {
             if let Some(performance_profile) = performance_profile {
                 perf_handle
                     .profile_sender
                     .send(performance_profile.to_string())
                     .await
                     .map_err(|err| fdo::Error::Failed(err.to_string()))?;
+                perf_handle.set_active_performance_profile(&performance_profile.to_string());
             }
         }
 

--- a/tailord/src/dbus/profiles.rs
+++ b/tailord/src/dbus/profiles.rs
@@ -1,9 +1,10 @@
-use tailor_api::{ProfileInfo, LedDeviceInfo};
+use tailor_api::{LedDeviceInfo, ProfileInfo};
 use zbus::{dbus_interface, fdo};
 
 use crate::{
     fancontrol::FanRuntimeHandle,
     led::LedRuntimeHandle,
+    performance::PerformanceProfileRuntimeHandle,
     profiles::{Profile, PROFILE_DIR},
     util,
 };
@@ -11,6 +12,7 @@ use crate::{
 pub struct ProfileInterface {
     pub fan_handles: Vec<FanRuntimeHandle>,
     pub led_handles: Vec<LedRuntimeHandle>,
+    pub performance_profile_handle: Option<PerformanceProfileRuntimeHandle>,
 }
 
 #[dbus_interface(name = "com.tux.Tailor.Profiles")]
@@ -74,7 +76,11 @@ impl ProfileInterface {
     }
 
     async fn reload(&mut self) -> fdo::Result<()> {
-        let Profile { fans, leds } = Profile::load();
+        let Profile {
+            fans,
+            leds,
+            performance_profile,
+        } = Profile::load();
 
         for (idx, fan_handle) in self.fan_handles.iter().enumerate() {
             let profile = fans.get(idx).cloned().unwrap_or_default();
@@ -92,6 +98,16 @@ impl ProfileInterface {
                 .send(profile)
                 .await
                 .map_err(|err| fdo::Error::Failed(err.to_string()))?;
+        }
+
+        if let Some(perf_handle) = &self.performance_profile_handle {
+            if let Some(performance_profile) = performance_profile {
+                perf_handle
+                    .profile_sender
+                    .send(performance_profile.to_string())
+                    .await
+                    .map_err(|err| fdo::Error::Failed(err.to_string()))?;
+            }
         }
 
         Ok(())

--- a/tailord/src/dbus/profiles.rs
+++ b/tailord/src/dbus/profiles.rs
@@ -73,6 +73,17 @@ impl ProfileInterface {
             .to_string())
     }
 
+    async fn get_available_performance_profile_names(&self) -> fdo::Result<Vec<String>> {
+        Ok(self
+            .performance_profile_handle
+            .as_ref()
+            .ok_or(fdo::Error::Failed(
+                "No performance profile handler available".to_string(),
+            ))?
+            .available_performance_profiles
+            .clone())
+    }
+
     async fn get_number_of_fans(&self) -> fdo::Result<u8> {
         Ok(self.fan_handles.len() as u8)
     }

--- a/tailord/src/main.rs
+++ b/tailord/src/main.rs
@@ -128,7 +128,7 @@ async fn start_runtime() {
     let profile_interface = ProfileInterface {
         led_handles: led_handles.clone(),
         fan_handles: fan_handles.clone(),
-        performance_profile_handle: performance_profile_handle.clone(),
+        performance_profile_handle,
     };
 
     let led_interface = LedInterface {

--- a/tailord/src/main.rs
+++ b/tailord/src/main.rs
@@ -9,7 +9,7 @@ pub mod util;
 
 use std::future::pending;
 
-use dbus::{FanInterface, ProfileInterface, PerformanceInterface};
+use dbus::{FanInterface, PerformanceInterface, ProfileInterface};
 use profiles::Profile;
 use tuxedo_ioctl::hal::IoInterface;
 use zbus::ConnectionBuilder;
@@ -139,8 +139,8 @@ async fn start_runtime() {
         handles: fan_handles,
     };
 
-    let performance_profile_interface = PerformanceInterface{
-        handler: performance_profile_handle
+    let performance_profile_interface = PerformanceInterface {
+        handler: performance_profile_handle,
     };
 
     tracing::debug!("Connecting to DBUS as {DBUS_NAME}");

--- a/tailord/src/main.rs
+++ b/tailord/src/main.rs
@@ -9,7 +9,7 @@ pub mod util;
 
 use std::future::pending;
 
-use dbus::{FanInterface, ProfileInterface};
+use dbus::{FanInterface, ProfileInterface, PerformanceInterface};
 use profiles::Profile;
 use tuxedo_ioctl::hal::IoInterface;
 use zbus::ConnectionBuilder;
@@ -128,7 +128,7 @@ async fn start_runtime() {
     let profile_interface = ProfileInterface {
         led_handles: led_handles.clone(),
         fan_handles: fan_handles.clone(),
-        performance_profile_handle,
+        performance_profile_handle: performance_profile_handle.clone(),
     };
 
     let led_interface = LedInterface {
@@ -137,6 +137,10 @@ async fn start_runtime() {
 
     let fan_interface = FanInterface {
         handles: fan_handles,
+    };
+
+    let performance_profile_interface = PerformanceInterface{
+        handler: performance_profile_handle
     };
 
     tracing::debug!("Connecting to DBUS as {DBUS_NAME}");
@@ -149,6 +153,8 @@ async fn start_runtime() {
         .serve_at(DBUS_PATH, fan_interface)
         .unwrap()
         .serve_at(DBUS_PATH, profile_interface)
+        .unwrap()
+        .serve_at(DBUS_PATH, performance_profile_interface)
         .unwrap()
         .build()
         .await

--- a/tailord/src/performance.rs
+++ b/tailord/src/performance.rs
@@ -1,0 +1,79 @@
+use std::{sync::Arc, time::Duration};
+
+use tokio::sync::{broadcast, mpsc};
+use tuxedo_ioctl::hal::traits::HardwareDevice;
+
+use crate::suspend::get_suspend_receiver;
+
+#[derive(Debug)]
+pub struct PerformanceProfile(String);
+
+impl ToString for PerformanceProfile {
+    fn to_string(&self) -> String {
+        self.0.to_string()
+    }
+}
+
+impl PerformanceProfile {
+    pub fn new(value: impl ToString) -> Self {
+        Self(value.to_string())
+    }
+}
+
+#[derive(Clone)]
+pub struct PerformanceProfileRuntimeHandle {
+    pub profile_sender: mpsc::Sender<String>,
+}
+
+pub struct PerformanceProfileRuntime {
+    profile_receiver: mpsc::Receiver<String>,
+    /// Device i/o interface.
+    io: Arc<dyn HardwareDevice>,
+    /// Default profile
+    default_performance_profile: String,
+}
+
+impl PerformanceProfileRuntime {
+    // initialize global instance at startup
+    #[tracing::instrument(skip(io))]
+    pub fn new(
+        io: Arc<dyn HardwareDevice>,
+        performance_profile: Option<PerformanceProfile>,
+        default_performance_profile: String,
+    ) -> (PerformanceProfileRuntimeHandle, PerformanceProfileRuntime) {
+        let (profile_sender, profile_receiver) = mpsc::channel(1);
+        match performance_profile {
+            Some(profile) => io
+                .set_odm_performance_profile(&profile.to_string())
+                .unwrap(),
+            None => io
+                .set_odm_performance_profile(&default_performance_profile)
+                .unwrap(),
+        }
+        (
+            PerformanceProfileRuntimeHandle { profile_sender },
+            PerformanceProfileRuntime {
+                profile_receiver,
+                io,
+                default_performance_profile,
+            },
+        )
+    }
+
+    #[tracing::instrument(skip(self))]
+    pub async fn run(mut self) {
+        loop {
+            tokio::select! {
+                new_profile = self.profile_receiver.recv() => {
+                    if let Some(profile) = new_profile {
+                        tracing::info!("Loading performance profile {profile}");
+                        self.io.set_odm_performance_profile(&profile).unwrap();
+                    } else {
+                        break;
+                    }
+                },
+                _ = tokio::time::sleep(Duration::from_millis(1000)) => {},
+            }
+        }
+    }
+}

--- a/tailord/src/performance.rs
+++ b/tailord/src/performance.rs
@@ -23,6 +23,7 @@ impl PerformanceProfile {
 #[derive(Clone)]
 pub struct PerformanceProfileRuntimeHandle {
     pub profile_sender: mpsc::Sender<String>,
+    pub performance_profile: String,
 }
 
 pub struct PerformanceProfileRuntime {
@@ -42,16 +43,17 @@ impl PerformanceProfileRuntime {
         default_performance_profile: String,
     ) -> (PerformanceProfileRuntimeHandle, PerformanceProfileRuntime) {
         let (profile_sender, profile_receiver) = mpsc::channel(1);
-        match performance_profile {
-            Some(profile) => io
-                .set_odm_performance_profile(&profile.to_string())
-                .unwrap(),
-            None => io
-                .set_odm_performance_profile(&default_performance_profile)
-                .unwrap(),
-        }
+        let performance_profile = match performance_profile {
+            Some(profile) => profile.to_string(),
+            None => default_performance_profile.to_string(),
+        };
+        io.set_odm_performance_profile(&performance_profile)
+            .unwrap();
         (
-            PerformanceProfileRuntimeHandle { profile_sender },
+            PerformanceProfileRuntimeHandle {
+                profile_sender,
+                performance_profile,
+            },
             PerformanceProfileRuntime {
                 profile_receiver,
                 io,

--- a/tailord/src/performance.rs
+++ b/tailord/src/performance.rs
@@ -82,7 +82,9 @@ impl PerformanceProfileRuntime {
                 tracing::info!("Loading performance profile {profile}");
                 self.io.set_odm_performance_profile(&profile).unwrap();
             } else {
-                tracing::warn!("Stopping runtime, the performance profile channel sender has probably dropped");
+                tracing::warn!(
+                    "Stopping runtime, the performance profile channel sender has probably dropped"
+                );
                 break;
             }
         }

--- a/tailord/src/performance.rs
+++ b/tailord/src/performance.rs
@@ -82,7 +82,7 @@ impl PerformanceProfileRuntime {
                 tracing::info!("Loading performance profile {profile}");
                 self.io.set_odm_performance_profile(&profile).unwrap();
             } else {
-                tracing::warn!("Received empty performance profile, stopping runtime");
+                tracing::warn!("Stopping runtime, the performance profile channel sender has probably dropped");
                 break;
             }
         }

--- a/tailord/src/profiles.rs
+++ b/tailord/src/profiles.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, path::Component};
 
-use crate::fancontrol::profile::FanProfile;
-use tailor_api::{ColorProfile, LedProfile, ProfileInfo, LedDeviceInfo};
+use crate::{fancontrol::profile::FanProfile, performance::PerformanceProfile};
+use tailor_api::{ColorProfile, LedDeviceInfo, LedProfile, ProfileInfo};
 use zbus::fdo;
 
 use super::util;
@@ -38,10 +38,11 @@ fn load_fan_profile(name: &str) -> fdo::Result<FanProfile> {
     FanProfile::load_config(fan_path(name)?)
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct Profile {
     pub fans: Vec<FanProfile>,
     pub leds: HashMap<LedDeviceInfo, ColorProfile>,
+    pub performance_profile: Option<PerformanceProfile>,
 }
 
 impl Profile {
@@ -95,9 +96,14 @@ impl Profile {
             })
             .collect();
 
+        let performance_profile = profile_info
+            .performance_profile
+            .map(PerformanceProfile::new);
+
         Self {
             fans: fan,
             leds: led,
+            performance_profile,
         }
     }
 

--- a/tuxedo_ioctl/src/hal/traits.rs
+++ b/tuxedo_ioctl/src/hal/traits.rs
@@ -2,7 +2,7 @@ use std::fmt::Debug;
 
 use super::IoctlResult;
 
-pub trait HardwareDevice: Debug {
+pub trait HardwareDevice: Send + Sync + Debug {
     fn device_interface_id_str(&self) -> IoctlResult<String>;
     fn device_model_id_str(&self) -> IoctlResult<String>;
     fn set_enable_mode_set(&self, enabled: bool) -> IoctlResult<()>;
@@ -30,12 +30,12 @@ pub trait HardwareDevice: Debug {
     fn get_default_odm_performance_profile(&self) -> IoctlResult<String>;
 }
 
-pub trait WebcamDevice: Debug {
+pub trait WebcamDevice: Send + Sync + Debug {
     fn set_webcam(&self, status: bool) -> IoctlResult<()>;
     fn get_webcam(&self) -> IoctlResult<bool>;
 }
 
-pub trait TdpDevice: Debug {
+pub trait TdpDevice: Send + Sync + Debug {
     fn get_number_tdps(&self) -> IoctlResult<u8>;
     fn get_tdp_descriptors(&self) -> IoctlResult<Vec<String>>;
     fn get_tdp_min(&self, tdp_index: u8) -> IoctlResult<i32>;

--- a/tuxedo_ioctl/src/hal/uniwill.rs
+++ b/tuxedo_ioctl/src/hal/uniwill.rs
@@ -176,7 +176,8 @@ impl HardwareDevice for UniwillHardware {
     fn get_default_odm_performance_profile(&self) -> IoctlResult<String> {
         let available_profiles = read::uw::profs_available(&self.file)?;
         if available_profiles > 0 {
-            let nr_tdps = self.get_number_tdps()?;
+            // TODO(uniwill) - get_number_tdps() always return -19 on my Pulse 15 Gen1
+            let nr_tdps = self.get_number_tdps().unwrap_or_default();
             let profile = if nr_tdps > 0 {
                 // LEDs only case (default to LEDs off)
                 PERF_PROF_OVERBOOST


### PR DESCRIPTION
Given my understanding of the architecture, I think I added the support for performance profiles. 

It add a new optional config profile directive

```json
{
    "fans": ["default"],
    ...
    "performance_profile": "power_save"
}
```

The options are per device type:
* Clevo: quiet, power_saving, entertainment, performance
* Uniwill: power_save, enthusiast, overboost

If `performance_profile` is not set, we default to the platform specific  `io.get_default_odm_performance_profile()`.

When the runtime starts, the performance profile is set accordingly and `ProfileInterface::reload()` takes care of updating the profile.

Am I missing anything?
 