### PR TITLE
ci: add nix-build action

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -1,0 +1,31 @@
+name: "Nix build"
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+jobs:
+  build:
+    name: ${{ matrix.attribute }} / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+        attribute:
+          - .#devShells.x86_64-linux.default
+          - .#packages.x86_64-linux.tailord
+          - .#packages.x86_64-linux.tailor_gui
+          - .#checks.x86_64-linux.formatting
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v20
+      with:
+        extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+    # - uses: cachix/cachix-action@v12
+    #   with:
+    #     name: TODO: cachix username here
+    #     authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    #     signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+    - run: nix build "${{matrix.attribute}}"

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -25,7 +25,7 @@ jobs:
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
     # - uses: cachix/cachix-action@v12
     #   with:
-    #     name: TODO: cachix username here
+    #     name: tuxedo-rs
     #     authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     #     signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
     - run: nix build "${{matrix.attribute}}"

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -23,9 +23,8 @@ jobs:
       with:
         extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-    # - uses: cachix/cachix-action@v12
-    #   with:
-    #     name: tuxedo-rs
-    #     authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    #     signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+    - uses: cachix/cachix-action@v12
+      with:
+        name: tuxedo-rs
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
     - run: nix build "${{matrix.attribute}}"

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,11 @@
 {
   description = "Rust libraries for interacting with hardware from TUXEDO Computers";
 
+  nixConfig = {
+    extra-substituters = "https://tuxedo-rs.cachix.org";
+    extra-trusted-public-keys = "TODO";
+  };
+
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   nixConfig = {
     extra-substituters = "https://tuxedo-rs.cachix.org";
-    extra-trusted-public-keys = "TODO";
+    extra-trusted-public-keys = "tuxedo-rs.cachix.org-1:blECq3BtB0X84VUHZAxvSJx3esqsuRdm59j2PCaOZ4I=";
   };
 
   inputs = {


### PR DESCRIPTION
I have left the cachix bit commented out for now. The build should be possible without it.

You either need an `authToken` or a `signingKey`. The other can be deleted.