### PR TITLE
refresh fan_speed after suspend

### DIFF
--- a/tailord/src/fancontrol/runtime.rs
+++ b/tailord/src/fancontrol/runtime.rs
@@ -36,7 +36,9 @@ impl FanRuntimeData {
 
             tokio::select! {
                 _ = tokio::time::sleep(delay) => {},
-                _ = process_suspend(&mut self.suspend_receiver) => {}
+                _ = process_suspend(&mut self.suspend_receiver) => {
+                    self.fan_speed = self.io.get_fan_speed_percent(0).unwrap();
+                }
             }
         }
     }


### PR DESCRIPTION
This is needed on systems where the hardware changes the value on its own after suspend and the cached value becomes stale.

fixes https://github.com/AaronErhardt/tuxedo-rs/issues/19