### PR TITLE
fix(tailor-cli): reload profiles after setting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1297,7 +1297,7 @@ dependencies = [
 
 [[package]]
 name = "tailor"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "clap",
  "clap_complete",
@@ -1331,7 +1331,7 @@ dependencies = [
 
 [[package]]
 name = "tailord"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "futures",
  "futures-lite",

--- a/tailor_cli/Cargo.toml
+++ b/tailor_cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tailor"
-version = "0.2.1"
+version = "0.2.2"
 authors = [
   "Aaron Erhardt <aaron.erhardt@t-online.de>",
   "Marc Jakobi <mrcjkb89@outlook.com>"

--- a/tailor_cli/src/profile.rs
+++ b/tailor_cli/src/profile.rs
@@ -20,7 +20,14 @@ pub(crate) async fn handle(cmd: ProfileCommand) -> Result<()> {
             let active_profile_str = format!("{} (active)", active_profile).bold().green();
             println!("{}\n{}", active_profile_str, inactive_profiles.join("\n"));
         }
-        ProfileCommand::Set { name } => connection.set_active_global_profile_name(&name).await?,
+        ProfileCommand::Set { name } => {
+            connection
+                .set_active_global_profile_name(&name)
+                .await?;
+            connection
+                .reload()
+                .await?;
+        }
         ProfileCommand::Cycle { verbose, notify } => {
             let active_profile = connection.get_active_global_profile_name().await?;
             let profiles: Vec<String> = connection.list_global_profiles().await?;
@@ -35,6 +42,9 @@ pub(crate) async fn handle(cmd: ProfileCommand) -> Result<()> {
                 let profile_updated_msg = format!("Current profile: {}", next_profile_name);
                 connection
                     .set_active_global_profile_name(next_profile_name)
+                    .await?;
+                connection
+                    .reload()
                     .await?;
                 if verbose {
                     println!("{}", profile_updated_msg)

--- a/tailor_gui/Cargo.toml
+++ b/tailor_gui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tailor_gui"
-version = "0.2.0"
+version = "0.2.2"
 authors = ["Aaron Erhardt <aaron.erhardt@t-online.de>"]
 edition = "2021"
 publish = false

--- a/tailord/Cargo.toml
+++ b/tailord/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tailord"
 authors = ["Aaron Erhardt <aaron.erhardt@t-online.de>"]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "GPL-2.0+"
 description = "Daemon handling fan, keyboard and general HW support for Tuxedo laptops (part of tuxedo-rs)"


### PR DESCRIPTION
When setting the profiles using `tailor-cli`, the profiles weren't reloaded.

P.S. I assume you want to use lockstep versioning for the tuxedo-rs suite (based on the [changelog](https://github.com/AaronErhardt/tuxedo-rs/pull/17/files#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2) in one of your open PRs) - I think this would make sense for packaging purposes.