### PR TITLE
build!(nix): reuse NixOS package

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -15,7 +15,7 @@ jobs:
         attribute:
           - .#devShells.x86_64-linux.default
           - .#packages.x86_64-linux.tuxedo-rs
-          - .#packages.x86_64-linux.tailor_gui
+          - .#packages.x86_64-linux.tailor-gui
           - .#checks.x86_64-linux.formatting
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -44,7 +44,9 @@ Since I have limited access to hardware, please consider adding your device(s) t
 
 ## Installation
 
-Currently, tuxedo-rs isn't available from package archives so you have to install it from source.
+[![Packaging status](https://repology.org/badge/vertical-allrepos/tuxedo-rs.svg)](https://repology.org/project/tuxedo-rs/versions)
+
+Currently, tuxedo-rs isn't available from other package archives so you have to install it from source.
 
 ### Tuxedo driver modules
 
@@ -136,33 +138,15 @@ cargo install --path tailor_cli
 tailor --help
 ```
 
-### On NixOS
+### NixOS
 
-To install tailor-rs on NixOS, with flakes enabled, add
-the following to your flake.nix:
+tuxedo-rs can be [enabled on NixOS with the following options](https://search.nixos.org/options?channel=unstable&from=0&size=50&sort=relevance&type=packages&query=tuxedo-rs):
 
 ```nix
 {
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    tuxedo-rs.url = "github:AaronErhardt/tuxedo-rs";
-  }
-
-  outputs = {
-    nixpkgs,
-    tuxedo-rs,
-   ...
-  } : {
-    nixosConfigurations.myConfiguration = nixpkgs.lib.nixosSystem {
-      modules = [
-        tuxedo-rs.nixosModules.default
-      ];
-
-      services.tuxedo-rs = {
-        enable = true;
-        tailor_gui.enable = true;
-      };
-    };
+  hardware.tuxedo-rs = {
+    enable = true;
+    tailor-gui.enable = true;
   };
 }
 ```

--- a/flake.lock
+++ b/flake.lock
@@ -21,11 +21,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -35,12 +35,15 @@
       }
     },
     "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
         "type": "github"
       },
       "original": {
@@ -72,11 +75,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1682109806,
-        "narHash": "sha256-d9g7RKNShMLboTWwukM+RObDWWpHKaqTYXB48clBWXI=",
+        "lastModified": 1695806987,
+        "narHash": "sha256-fX5kGs66NZIxCMcpAGIpxuftajHL8Hil1vjHmjjl118=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2362848adf8def2866fabbffc50462e929d7fffb",
+        "rev": "f3dab3509afca932f3f4fd0908957709bb1c1f57",
         "type": "github"
       },
       "original": {
@@ -88,16 +91,16 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1678872516,
-        "narHash": "sha256-/E1YwtMtFAu2KUQKV/1+KFuReYPANM2Rzehk84VxVoc=",
+        "lastModified": 1685801374,
+        "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9b8e5abb18324c7fe9f07cb100c3cd4a29cda8b8",
+        "rev": "c37ca420157f4abc31e26f436c1145f8951ff373",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.11",
+        "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -113,11 +116,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1682326782,
-        "narHash": "sha256-wj7p7iEwQXAfTZ6QokAe0dMbpQk5u7ympDnaiPvbv1w=",
+        "lastModified": 1695576016,
+        "narHash": "sha256-71KxwRhTfVuh7kNrg3/edNjYVg9DCyKZl2QIKbhRggg=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "56cd2d47a9c937be98ab225cf014b450f1533cdb",
+        "rev": "cb770e93516a1609652fa8e945a0f310e98f10c0",
         "type": "github"
       },
       "original": {
@@ -134,6 +137,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -28,12 +28,7 @@
       "x86_64-linux"
     ];
 
-    overlay = import ./nix/overlay.nix {
-      inherit
-        self
-        nixpkgs
-        ;
-    };
+    overlay = import ./nix/overlay.nix {inherit self;};
   in
     flake-utils.lib.eachSystem supportedSystems (system: let
       pkgs = import nixpkgs {
@@ -55,7 +50,7 @@
         name = "tuxedo-rs-devShell";
         buildInputs =
           (with pkgs;
-            with pkgs.rustPlatform.rust; [
+            with pkgs.rustPlatform; [
               cargo
               rustc
               meson
@@ -85,7 +80,7 @@
         inherit
           (pkgs)
           tuxedo-rs
-          tailor_gui
+          tailor-gui
           ;
       };
 
@@ -94,7 +89,7 @@
         inherit
           (pkgs)
           tuxedo-rs
-          tailor_gui
+          tailor-gui
           ;
       };
     })

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,3 +1,4 @@
+# TODO: Remove this after NixOS 23.11 release
 {
   config,
   lib,
@@ -8,12 +9,12 @@ with lib; let
   cfg = config.services.tuxedo-rs;
 in {
   options = {
-    services.tuxedo-rs = {
+    hardware.tuxedo-rs = {
       enable = mkEnableOption ''
         Rust utilities for interacting with hardware from TUXEDO Computers.
       '';
 
-      tailor_gui.enable = mkEnableOption ''
+      tailor-gui.enable = mkEnableOption ''
         Alternative to Tuxedo Control Center, written in Rust.
       '';
     };
@@ -44,8 +45,8 @@ in {
 
       environment.systemPackages = [pkgs.tuxedo-rs];
     }
-    (mkIf cfg.tailor_gui.enable {
-      environment.systemPackages = [pkgs.tailor_gui];
+    (mkIf cfg.tailor-gui.enable {
+      environment.systemPackages = [pkgs.tailor-gui];
     })
   ]);
 }

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,84 +1,25 @@
-{
-  self,
-  nixpkgs,
-}: final: prev:
-with final.pkgs.stdenv; let
-  # XXX: The nixos-22.11 rustPlatform is too old to build this.
-  #TODO: We should use final.pkgs.rustPlatform when NixOS 23.05 has been released.
-  pkgs = import nixpkgs {inherit (final.pkgs) system;};
-  rustPlatform = pkgs.rustPlatform;
+{self}: final: prev: let
+  pkgs = prev;
+  lib = final.lib;
 
-  tuxedo-rs = with pkgs.lib; let
+  tuxedo-rs = pkgs.tuxedo-rs.overrideAttrs (oa: {
     src = self;
-  in
-    rustPlatform.buildRustPackage {
-      pname = "tuxedo-rs";
-      inherit ((importTOML "${src}/tailord/Cargo.toml").package) version;
-
-      inherit src;
-
-      doCheck = false;
-
-      cargoLock = {
-        lockFile = self + "/Cargo.lock";
-      };
-
-      postInstall = ''
-        mkdir -p $out/share/dbus-1/system.d
-        cp ${self}/tailord/com.tux.Tailor.conf $out/share/dbus-1/system.d
-      '';
-
-      meta = with final.lib; {
-        description = "Daemon handling fan, keyboard and general HW support for Tuxedo laptops (part of tuxedo-rs)";
-        homepage = "https://github.com/AaronErhardt/tuxedo-rs";
-        license = licenses.gpl2Only;
-      };
+    version = ((lib.importTOML "${self}/tailord/Cargo.toml").package).version;
+    cargoDeps = pkgs.rustPlatform.importCargoLock {
+      lockFile = self + "/Cargo.lock";
     };
+  });
 
-  tailor_gui = with pkgs.lib; let
-    src = builtins.path {
-      path = self + "/tailor_gui";
-      name = "tailor_gui";
+  tailor-gui = pkgs.tailor-gui.overrideAttrs (oa: {
+    src = self;
+    version = ((lib.importTOML "${self}/tailor_gui/Cargo.toml").package).version;
+    cargoDeps = pkgs.rustPlatform.importCargoLock {
+      lockFile = self + "/tailor_gui/Cargo.lock";
     };
-  in
-    mkDerivation {
-      name = "tailor_gui";
-
-      inherit ((importTOML (src + "/Cargo.toml")).package) version;
-
-      inherit src;
-
-      cargoDeps = rustPlatform.importCargoLock {
-        lockFile = self + "/tailor_gui/Cargo.lock";
-      };
-
-      nativeBuildInputs = with rustPlatform;
-        [
-          rust.cargo
-          rust.rustc
-          cargoSetupHook
-        ]
-        ++ (with pkgs; [
-          pkg-config
-          desktop-file-utils
-          appstream-glib
-          makeWrapper
-        ]);
-
-      buildInputs = with pkgs; [
-        meson
-        ninja
-        libadwaita
-        gtk4
-      ];
-
-      postFixup = ''
-        wrapProgram $out/bin/tailor_gui --set XDG_DATA_DIRS "$out/share/gsettings-schemas/tailor_gui"
-      '';
-    };
+  });
 in {
   inherit
     tuxedo-rs
-    tailor_gui
+    tailor-gui
     ;
 }

--- a/tailor_cli/src/profile.rs
+++ b/tailor_cli/src/profile.rs
@@ -21,12 +21,8 @@ pub(crate) async fn handle(cmd: ProfileCommand) -> Result<()> {
             println!("{}\n{}", active_profile_str, inactive_profiles.join("\n"));
         }
         ProfileCommand::Set { name } => {
-            connection
-                .set_active_global_profile_name(&name)
-                .await?;
-            connection
-                .reload()
-                .await?;
+            connection.set_active_global_profile_name(&name).await?;
+            connection.reload().await?;
         }
         ProfileCommand::Cycle { verbose, notify } => {
             let active_profile = connection.get_active_global_profile_name().await?;
@@ -43,9 +39,7 @@ pub(crate) async fn handle(cmd: ProfileCommand) -> Result<()> {
                 connection
                     .set_active_global_profile_name(next_profile_name)
                     .await?;
-                connection
-                    .reload()
-                    .await?;
+                connection.reload().await?;
                 if verbose {
                     println!("{}", profile_updated_msg)
                 }

--- a/tailor_gui/Cargo.lock
+++ b/tailor_gui/Cargo.lock
@@ -1590,7 +1590,7 @@ dependencies = [
 
 [[package]]
 name = "tailor_gui"
-version = "0.2.0"
+version = "0.2.2"
 dependencies = [
  "futures",
  "gettext-rs",


### PR DESCRIPTION
I've added tuxedo-rs to NixOS/nixpkgs, and it is now available on the unstable branch.

This PR refactors the nix overlay to reuse the nixpkgs build, overriding the source, so that people who import this flake can use the latest `scm` version,

It also modifies the flake's module, so that it is in line with the NixOS module (we can delete this flake's module once NixOS 23.11 has been released).