### PR TITLE
build(nix): fix nixos module

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -6,7 +6,7 @@
   ...
 }:
 with lib; let
-  cfg = config.services.tuxedo-rs;
+  cfg = config.hardware.tuxedo-rs;
 in {
   options = {
     hardware.tuxedo-rs = {


### PR DESCRIPTION
There was still a reference to the old `services` module.