### PR TITLE
ci: automatic release management

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,23 @@
+---
+name: Release Please Automatic Semver
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    name: release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        with:
+          release-type: rust
+          command: manifest
+          package-name: tuxedo-rs
+          changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"deps","section":"Dependencies","hidden":false}]'

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,0 +1,9 @@
+{
+    "tuxedo_ioctl": "0.2.3",
+    "tuxedo_sysfs": "0.2.3",
+    "tailord": "0.2.3",
+    "tailor_api": "0.2.3",
+    "tailor_client": "0.2.3",
+    "tailor_cli": "0.2.3",
+    "tailor_gui": "0.2.3"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing guide
+
+Contributions are more than welcome!
+
+## Commit messages / PR titles
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
+for PR titles, which become the commit messages after a squash merge.
+
+The most important prefixes you should have in mind are:
+
+- `feat:` which represents a new feature, and correlates to a [SemVer](https://semver.org/)
+  minor.
+- `fix:` which represents bug fixes, and correlates to a SemVer patch.
+- `deps:` which represents dependency updates, and correlates to a SemVer patch.
+- `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change
+  (indicated by the !).
+- `docs:` which represents documentation, and does not correlate to a version bump.
+- `chore:` which represents miscellaneous changes,
+  and does not correlate to a version bump.
+
+See also the [`release-please`](./.github/workflows/release-please.yml)
+for the mapping of commit prefixes to changelog entry.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1320,7 +1320,7 @@ dependencies = [
 
 [[package]]
 name = "tailor_client"
-version = "0.2.1"
+version = "0.2.3"
 dependencies = [
  "serde_json",
  "tailor_api",
@@ -1555,7 +1555,7 @@ dependencies = [
 
 [[package]]
 name = "tuxedo_sysfs"
-version = "0.2.0"
+version = "0.2.3"
 dependencies = [
  "futures",
  "sudo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,12 @@ members = [
 exclude = [
     "tailor_gui",
 ]
+
+[workspace.package]
+name = "tuxedo-rs"
+version = "0.2.3"
+rust-version = "1.72.0"
+authors = ["Aaron Erhardt <aaron.erhardt@t-online.de>"]
+edition = "2021"
+license = "GPL-2.0+"
+repository = "https://github.com/AaronErhardt/tuxedo-rs"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,26 @@
+{
+  "plugins": ["cargo-workspace"],
+  "packages": {
+    "tuxedo_ioctl": {
+        "release-type": "rust"
+    },
+    "tuxedo_sysfs": {
+        "release-type": "rust"
+    },
+    "tailord": {
+        "release-type": "rust"
+    },
+    "tailor_api": {
+        "release-type": "rust"
+    },
+    "tailor_client": {
+        "release-type": "rust"
+    },
+    "tailor_cli": {
+        "release-type": "rust"
+    },
+    "tailor_gui": {
+        "release-type": "rust"
+    }
+  }
+}

--- a/tailor_api/Cargo.toml
+++ b/tailor_api/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "tailor_api"
-authors = ["Aaron Erhardt <aaron.erhardt@t-online.de>"]
-version = "0.2.3"
-edition = "2021"
-license = "GPL-2.0+"
 description = "API types for communication with tailord (part of tuxedo-rs)"
-repository = "https://github.com/AaronErhardt/tuxedo-rs"
+version = "0.2.3"
+rust-version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 atoi = "2"

--- a/tailor_cli/Cargo.toml
+++ b/tailor_cli/Cargo.toml
@@ -1,14 +1,16 @@
 [package]
 name = "tailor"
-version = "0.2.3"
+description = "Tailor CLI (part of tuxedo-rs)"
 authors = [
   "Aaron Erhardt <aaron.erhardt@t-online.de>",
   "Marc Jakobi <mrcjkb89@outlook.com>"
 ]
-edition = "2021"
 publish = false
-description = "Tailor CLI (part of tuxedo-rs)"
-repository = "https://github.com/AaronErhardt/tuxedo-rs"
+version = "0.2.3"
+rust-version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 tailor_api = {version = "0.2.1", path = "../tailor_api" }

--- a/tailor_client/Cargo.toml
+++ b/tailor_client/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "tailor_client"
-authors = ["Aaron Erhardt <aaron.erhardt@t-online.de>"]
-version = "0.2.1"
-edition = "2021"
-license = "GPL-2.0+"
 description = "Client library for tailord (part of tuxedo-rs)"
-repository = "https://github.com/AaronErhardt/tuxedo-rs"
+version = "0.2.3"
+rust-version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 thiserror = "1"

--- a/tailord/Cargo.toml
+++ b/tailord/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "tailord"
-authors = ["Aaron Erhardt <aaron.erhardt@t-online.de>"]
-version = "0.2.3"
-edition = "2021"
-license = "GPL-2.0+"
 description = "Daemon handling fan, keyboard and general HW support for Tuxedo laptops (part of tuxedo-rs)"
-repository = "https://github.com/AaronErhardt/tuxedo-rs"
+version = "0.2.3"
+rust-version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 futures = "0.3"

--- a/tuxedo_ioctl/Cargo.toml
+++ b/tuxedo_ioctl/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "tuxedo_ioctl"
-authors = ["Aaron Erhardt <aaron.erhardt@t-online.de>"]
-version = "0.2.3"
-edition = "2021"
-license = "GPL-2.0+"
 description = "Tuxedo ioctl interface (part of tuxedo-rs)"
-repository = "https://github.com/AaronErhardt/tuxedo-rs"
+version = "0.2.3"
+rust-version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 nix = { version = "0.26", features = ["ioctl"] }

--- a/tuxedo_sysfs/Cargo.toml
+++ b/tuxedo_sysfs/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
 name = "tuxedo_sysfs"
-authors = ["Aaron Erhardt <aaron.erhardt@t-online.de>"]
-version = "0.2.0"
-edition = "2021"
-license = "GPL-2.0+"
 description = "Tuxedo sysfs interface (part of tuxedo-rs)"
-repository = "https://github.com/AaronErhardt/tuxedo-rs"
+version = "0.2.3"
+rust-version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
 
 [dependencies]
 futures = "0.3"


### PR DESCRIPTION
Closes #30 

Will create release PRs, bumping the version and adding changelog entries, based on [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).

Currently, conventional commits are not enforced. I haven't yet found a way to do so in a way that works nicely with the `release-please` workflow.
If people contribute with non-conventional commits, you can make the PR title CC compliant, and squash merge.

- [x] You may also need to set "Allow GitHub Actions to create and approve pull requests" under repository Settings > Actions > General.