### PR TITLE
ci: automate flake.lock updates

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,33 @@
+name: update-flake-lock
+on:
+  workflow_dispatch: # allows manual triggering
+  schedule:
+    - cron: '0 0 * * 0' # runs weekly on Sunday at 00:00
+
+jobs:
+  lockfile:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install Nix
+        uses: cachix/install-nix-action@v16
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+      - name: Update flake.lock
+        uses: DeterminateSystems/update-flake-lock@v12
+        with:
+          token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
+          pr-title: "chore: update flake.lock" # Title of PR to be created
+          pr-labels: |                  # Labels to be set on the PR
+            dependencies
+            automated
+      # NOTE: I've left this commented out for now (which means PRs have to be merged manually)
+      # To enable this, some repo rules have to be defined (see the workflow's readme).
+      # - uses: reitermarkus/automerge@v2
+      #   with:
+      #     token: ${{ secrets.GH_TOKEN_FOR_UPDATES }}
+      #     merge-method: squash
+      #     pull-request: ${{ github.event.inputs.pull-request }}


### PR DESCRIPTION
This requires a [`GH_TOKEN_FOR_UPDATES`](https://github.com/DeterminateSystems/update-flake-lock#with-a-personal-authentication-token) to work.

You can also configure this to [auto-merge](https://github.com/reitermarkus/automerge), but I've left that bit commented out for now, as it requires certain branch rules and repo configurations.