### PR TITLE
ci: set release PR title pattern

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,3 +21,4 @@ jobs:
           command: manifest
           package-name: tuxedo-rs
           changelog-types: '[{"type":"feat","section":"Features","hidden":false},{"type":"fix","section":"Bug Fixes","hidden":false},{"type":"deps","section":"Dependencies","hidden":false}]'
+          pull-request-title-pattern: "chore: release new version"


### PR DESCRIPTION
Relates to #48.
I see a bunch of `undefined` PR title patterns in the failed release logs, and the error message is
"Cannot read properties of undefined". Maybe this will help...