### PR TITLE
Fix: properly handle monochrome devices

### DIFF
--- a/tailor_api/src/color.rs
+++ b/tailor_api/src/color.rs
@@ -1,3 +1,4 @@
+use crate::led::LedControllerMode;
 use atoi::FromRadix16;
 use std::{fmt::Display, io, str::FromStr};
 
@@ -22,25 +23,28 @@ pub enum ColorProfile {
     Multiple(Vec<ColorPoint>),
 }
 
-impl Default for ColorProfile {
-    fn default() -> Self {
-        Self::Multiple(vec![
-            ColorPoint {
-                color: Color { r: 255, g: 0, b: 0 },
-                transition: ColorTransition::Linear,
-                transition_time: 6000,
-            },
-            ColorPoint {
-                color: Color { r: 0, g: 255, b: 0 },
-                transition: ColorTransition::Linear,
-                transition_time: 6000,
-            },
-            ColorPoint {
-                color: Color { r: 0, g: 0, b: 255 },
-                transition: ColorTransition::Linear,
-                transition_time: 6000,
-            },
-        ])
+impl ColorProfile {
+    pub fn default(mode: LedControllerMode) -> Self {
+        match mode {
+            LedControllerMode::Monochrome => Self::None,
+            LedControllerMode::Rgb => Self::Multiple(vec![
+                ColorPoint {
+                    color: Color { r: 255, g: 0, b: 0 },
+                    transition: ColorTransition::Linear,
+                    transition_time: 6000,
+                },
+                ColorPoint {
+                    color: Color { r: 0, g: 255, b: 0 },
+                    transition: ColorTransition::Linear,
+                    transition_time: 6000,
+                },
+                ColorPoint {
+                    color: Color { r: 0, g: 0, b: 255 },
+                    transition: ColorTransition::Linear,
+                    transition_time: 6000,
+                },
+            ]),
+        }
     }
 }
 

--- a/tailor_api/src/led.rs
+++ b/tailor_api/src/led.rs
@@ -1,7 +1,15 @@
+#[derive(Debug, Copy, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum LedControllerMode {
+    Rgb,
+    Monochrome,
+}
+
 #[derive(Debug, Clone, Hash, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub struct LedDeviceInfo {
     pub device_name: String,
     pub function: String,
+    pub mode: LedControllerMode,
 }
 
 impl LedDeviceInfo {
@@ -9,6 +17,7 @@ impl LedDeviceInfo {
         let Self {
             device_name,
             function,
+            mode: _mode,
         } = self;
         format!("{device_name}::{function}")
     }

--- a/tailor_api/src/lib.rs
+++ b/tailor_api/src/lib.rs
@@ -5,5 +5,5 @@ mod profile;
 
 pub use color::{Color, ColorPoint, ColorProfile, ColorTransition};
 pub use fan::FanProfilePoint;
-pub use led::LedDeviceInfo;
+pub use led::{LedControllerMode, LedDeviceInfo};
 pub use profile::{LedProfile, ProfileInfo};

--- a/tailor_api/src/profile.rs
+++ b/tailor_api/src/profile.rs
@@ -1,3 +1,5 @@
+use crate::LedControllerMode;
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 pub struct ProfileInfo {
     pub fans: Vec<String>,
@@ -20,4 +22,5 @@ pub struct LedProfile {
     pub device_name: String,
     pub function: String,
     pub profile: String,
+    pub mode: LedControllerMode,
 }

--- a/tailord/src/dbus/led.rs
+++ b/tailord/src/dbus/led.rs
@@ -24,17 +24,17 @@ impl LedInterface {
         if info.leds.iter().any(|prof| prof.profile == name) {
             let info = Profile::load();
             for handle in &self.handles {
-                let profile = info
-                    .leds
-                    .iter()
-                    .find_map(|(info, profile)| {
-                        if info == &handle.info {
-                            Some(profile.clone())
-                        } else {
-                            None
-                        }
-                    })
-                    .unwrap_or_default();
+                let profile = match info.leds.iter().find_map(|(info, profile)| {
+                    if info == &handle.info {
+                        Some(profile.clone())
+                    } else {
+                        None
+                    }
+                }) {
+                    Some(color_profile) => color_profile,
+                    None => ColorProfile::default(handle.info.mode),
+                };
+
                 handle.profile_sender.send(profile).await.unwrap();
             }
         }

--- a/tailord/src/dbus/led.rs
+++ b/tailord/src/dbus/led.rs
@@ -24,16 +24,17 @@ impl LedInterface {
         if info.leds.iter().any(|prof| prof.profile == name) {
             let info = Profile::load();
             for handle in &self.handles {
-                let profile = match info.leds.iter().find_map(|(info, profile)| {
-                    if info == &handle.info {
-                        Some(profile.clone())
-                    } else {
-                        None
-                    }
-                }) {
-                    Some(color_profile) => color_profile,
-                    None => ColorProfile::default(handle.info.mode),
-                };
+                let profile = info
+                    .leds
+                    .iter()
+                    .find_map(|(info, profile)| {
+                        if info == &handle.info {
+                            Some(profile.clone())
+                        } else {
+                            None
+                        }
+                    })
+                    .unwrap_or_else(|| ColorProfile::default(handle.info.mode));
 
                 handle.profile_sender.send(profile).await.unwrap();
             }

--- a/tailord/src/dbus/profiles.rs
+++ b/tailord/src/dbus/profiles.rs
@@ -1,4 +1,4 @@
-use tailor_api::{LedDeviceInfo, ProfileInfo};
+use tailor_api::{ColorProfile, LedDeviceInfo, ProfileInfo};
 use zbus::{dbus_interface, fdo};
 
 use crate::{
@@ -92,7 +92,10 @@ impl ProfileInterface {
         }
 
         for led_handle in &self.led_handles {
-            let profile = leds.get(&led_handle.info).cloned().unwrap_or_default();
+            let profile = match leds.get(&led_handle.info).cloned() {
+                Some(color_profile) => color_profile,
+                None => ColorProfile::default(led_handle.info.mode),
+            };
             led_handle
                 .profile_sender
                 .send(profile)

--- a/tailord/src/led/mod.rs
+++ b/tailord/src/led/mod.rs
@@ -32,6 +32,7 @@ impl LedRuntime {
                 info: LedDeviceInfo {
                     device_name: data.controller.device_name.clone(),
                     function: data.controller.function.clone(),
+                    mode: data.controller.mode().clone(),
                 },
                 profile_sender,
                 color_sender,

--- a/tailord/src/main.rs
+++ b/tailord/src/main.rs
@@ -98,16 +98,19 @@ async fn start_runtime() {
     let mut led_handles = Vec::new();
     let mut led_runtimes = Vec::new();
     for led_device in led_devices {
-        let profile = match profile.leds.iter().find_map(|(info, profile)| {
-            if info.device_name == led_device.device_name && info.function == led_device.function {
-                Some(profile.clone())
-            } else {
-                None
-            }
-        }) {
-            Some(c) => c,
-            None => ColorProfile::default(led_device.mode()),
-        };
+        let profile = profile
+            .leds
+            .iter()
+            .find_map(|(info, profile)| {
+                if info.device_name == led_device.device_name
+                    && info.function == led_device.function
+                {
+                    Some(profile.clone())
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_else(|| ColorProfile::default(led_device.mode()));
 
         let (handle, runtime) = LedRuntime::new(LedRuntimeData {
             controller: led_device,

--- a/tailord/src/main.rs
+++ b/tailord/src/main.rs
@@ -42,7 +42,6 @@ fn main() {
 
 #[tracing::instrument]
 async fn start_runtime() {
-    println!("start_runtime()");
     tracing::info!("Starting tailord");
 
     // Setup shutdown

--- a/tuxedo_sysfs/src/led/controller.rs
+++ b/tuxedo_sysfs/src/led/controller.rs
@@ -1,10 +1,11 @@
 use std::io;
 
 use tailor_api::Color;
+use tailor_api::LedControllerMode;
 
 use crate::sysfs_util::{read_int_list, write_string};
 
-use super::{Controller, ControllerMode};
+use super::Controller;
 
 impl Controller {
     pub async fn new_rgb(
@@ -91,11 +92,11 @@ impl Controller {
         &self.function
     }
 
-    pub fn mode(&self) -> ControllerMode {
+    pub fn mode(&self) -> LedControllerMode {
         if self.intensities_file.is_some() {
-            ControllerMode::Rgb
+            LedControllerMode::Rgb
         } else {
-            ControllerMode::Monochrome
+            LedControllerMode::Monochrome
         }
     }
 }

--- a/tuxedo_sysfs/src/led/mod.rs
+++ b/tuxedo_sysfs/src/led/mod.rs
@@ -19,10 +19,3 @@ pub struct Controller {
     brightness_file: tokio_uring::fs::File,
     intensities_file: Option<tokio_uring::fs::File>,
 }
-
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
-#[non_exhaustive]
-pub enum ControllerMode {
-    Rgb,
-    Monochrome,
-}


### PR DESCRIPTION
Improves https://github.com/AaronErhardt/tuxedo-rs/issues/32

<hr>

This PR fixes a bug where if one uses `tailord` with a device that doesn't support RGB, `tailord` would still default to an RGB profile which changes over time, this would then reset the keyboard backlight each time the user tried to change it manually.

The issue is fixed by making the default `ColorProfile` dependent on the `LedControllerMode` (i.e. its support of RGB)

<hr>

Notes:
- This is my first Rust PR: hopefully, it doesn't suck too much :sweat_smile: 
- I am not 100% confident this is the right way to fix things - I am happy to improve this in any way