### PR TITLE
fix: fan too low warning message

### DIFF
--- a/tailord/src/fancontrol/profile.rs
+++ b/tailord/src/fancontrol/profile.rs
@@ -66,12 +66,13 @@ impl FanProfile {
                 51..=255 => (value.temp - 50).saturating_mul(2).min(100),
             };
             if min_speed > value.fan {
+                let invalid_fan_value = value.fan;
                 value.fan = min_speed;
                 tracing::warn!(
-                "Fan speed {}% at {}°C is too low. Falling back to {min_speed}%: `{file_name:?}`",
-                value.fan,
-                value.temp
-            );
+                    "Fan speed {}% at {}°C is too low. Falling back to {min_speed}%: `{file_name:?}`",
+                    invalid_fan_value,
+                    value.temp
+                );
             }
         }
 


### PR DESCRIPTION
I noticed that there was messages like the following in the `tailord.service` logs:
```
Fan speed 58% at 79°C is too low. Falling back to 58%
```

Then I realized we log the value after we change the invalid value, therefore we output the fixed value instead of the invalid one.