### PR TITLE
Support rustc 1.70.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 [workspace.package]
 name = "tuxedo-rs"
 version = "0.2.5"
-rust-version = "1.72.0"
+rust-version = "1.70.0"
 authors = ["Aaron Erhardt <aaron.erhardt@t-online.de>"]
 edition = "2021"
 license = "GPL-2.0+"


### PR DESCRIPTION
Hello and thanks for developing tuxedo-rs. Would it be possible to support slightly less new compiler versions? tailord seems to build, but tailor_cli does not