### PR TITLE
chore: fix .envrc

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-use flake -Lv
+use flake . -Lv


### PR DESCRIPTION
The syntax for entering nix flake devShells in nix-direnv has changed.